### PR TITLE
Override `_pxBoundsToTileRange` instead of  `_getTiledPixelBounds`.

### DIFF
--- a/src/leaflet.edgebuffer.js
+++ b/src/leaflet.edgebuffer.js
@@ -3,21 +3,20 @@
 if (typeof previousMethods === 'undefined') {
 	// Defining previously that object allows you to use that plugin even if you have overridden L.map
 	previousMethods = {
-		getTiledPixelBounds: L.GridLayer.prototype._getTiledPixelBounds
+		_pxBoundsToTileRange: L.GridLayer.prototype._pxBoundsToTileRange
 	};
 }
 
 L.GridLayer.include({
+  _pxBoundsToTileRange: function (bounds) {
+    var tileRange = previousMethods._pxBoundsToTileRange.apply(this, arguments);
+    
+    // Default is to not buffer edge tiles (edgeBufferTiles = 0).
+    var edgeBufferTiles = this.options.edgeBufferTiles || 0;
 
-  _getTiledPixelBounds : function(center, zoom, tileZoom) {
-    var pixelBounds = previousMethods.getTiledPixelBounds.call(this, center, zoom, tileZoom);
-    
-    if (this.options.edgeBufferTiles > 0) {
-      var pixelEdgeBuffer = this.options.edgeBufferTiles * this._getTileSize();
-      pixelBounds = new L.Bounds(pixelBounds.min.subtract([pixelEdgeBuffer, pixelEdgeBuffer]), pixelBounds.max.add([pixelEdgeBuffer, pixelEdgeBuffer]));
-    }
-    
-    return pixelBounds;
+    return new L.Bounds(
+      tileRange.min.subtract([edgeBufferTiles, edgeBufferTiles]),
+      tileRange.max.add([edgeBufferTiles, edgeBufferTiles]));
   }
 });
 


### PR DESCRIPTION
Similar to what was submitted in https://github.com/Leaflet/Leaflet/pull/3759,

It's a little simpler solution (no dependency on tileSize) to override `_pxBoundsToTileRange`.  But I admit that it feels hacky either way, so it's a pretty minor improvement.
