### PR TITLE
Rename a method for newer versions of leaflet.js.

### DIFF
--- a/src/leaflet.edgebuffer.js
+++ b/src/leaflet.edgebuffer.js
@@ -11,12 +11,12 @@ L.GridLayer.include({
 
   _getTiledPixelBounds : function(center, zoom, tileZoom) {
     var pixelBounds = previousMethods.getTiledPixelBounds.call(this, center, zoom, tileZoom);
-    
+
     if (this.options.edgeBufferTiles > 0) {
-      var pixelEdgeBuffer = this.options.edgeBufferTiles * this._getTileSize();
+      var pixelEdgeBuffer = this.options.edgeBufferTiles * this.getTileSize();
       pixelBounds = new L.Bounds(pixelBounds.min.subtract([pixelEdgeBuffer, pixelEdgeBuffer]), pixelBounds.max.add([pixelEdgeBuffer, pixelEdgeBuffer]));
     }
-    
+
     return pixelBounds;
   }
 });


### PR DESCRIPTION
As of leaflet.js ^1.0.0-beta.1, _getTileSize on GridLayer is now getTileSize.
