### PR TITLE
Fixes issue #15.

### DIFF
--- a/src/leaflet.edgebuffer.js
+++ b/src/leaflet.edgebuffer.js
@@ -31,8 +31,8 @@
       }
 
       if (edgeBufferTiles > 0) {
-        var pixelEdgeBuffer = edgeBufferTiles * this.options.tileSize;
-        pixelBounds = new L.Bounds(pixelBounds.min.subtract([pixelEdgeBuffer, pixelEdgeBuffer]), pixelBounds.max.add([pixelEdgeBuffer, pixelEdgeBuffer]));
+        var pixelEdgeBuffer = L.GridLayer.prototype.getTileSize.call(this).multiplyBy(edgeBufferTiles);
+        pixelBounds = new L.Bounds(pixelBounds.min.subtract(pixelEdgeBuffer), pixelBounds.max.add(pixelEdgeBuffer));
       }
       return pixelBounds;
     }


### PR DESCRIPTION
The code calls the prototype implementation of getTileSize() since it returns 'this.options.tileSize' as is, if it is already a point or it creates a Point from the user specified scalar value.
The scaling is then implemented via the Point member Point.multiplyBy.