### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 name: CI
 on: [push, pull_request]
+permissions:
+  contents: read
 jobs:
   typecheck:
     runs-on: ubuntu-latest

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,18 @@
+# Security Policy
+
+## Supported Versions
+
+Use this section to tell people about which versions of your project are
+currently being supported with security updates.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 2.x (alpha)    | :white_check_mark: |
+| 1.x     | :white_check_mark: |
+
+## Reporting a Vulnerability
+
+Public-knowledge vulnerabilities may be reported via the Issues page in GitHub at https://github.com/TolonUK/Leaflet.EdgeBuffer/issues.
+Private or sensitive vulnerabilities may be reported via the Security page in GitHub at https://github.com/TolonUK/Leaflet.EdgeBuffer/security.
+
+If you are unsure whether the vulnerability is sensitive or not, please treat it as sensitive and it will be triaged accordingly.


### PR DESCRIPTION
Potential fix for [https://github.com/TolonUK/Leaflet.EdgeBuffer/security/code-scanning/2](https://github.com/TolonUK/Leaflet.EdgeBuffer/security/code-scanning/2)

To fix the problem, we should explicitly declare a `permissions` block in the workflow file to restrict the capabilities of the GITHUB_TOKEN. For these jobs, only the ability to read repository contents (code) is required. This can be done by adding `permissions: contents: read` at the top of the file (root level), so it applies to all jobs in the workflow. This change should be made above the `jobs:` block in `.github/workflows/ci.yml` to minimize permissions according to the principle of least privilege.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
